### PR TITLE
Removing unnecessary placeholder

### DIFF
--- a/src/net/peng1104/SimpleClansExpansion.java
+++ b/src/net/peng1104/SimpleClansExpansion.java
@@ -200,9 +200,6 @@ public class SimpleClansExpansion extends PlaceholderExpansion {
 			case "clan_color_tag": {
 				return c.getColorTag();
 			}
-			case "clan_tag_label": {
-				return c.getTagLabel();
-			}
 			case "clan_tag": {
 				return c.getTag();
 			}


### PR DESCRIPTION
clan.getTagLabel() needs a boolean and the result would be the same of clanPlayer.getTagLabel()
And fixes this error:
`java.lang.NoSuchMethodError: net.sacredlabyrinth.phaed.simpleclans.Clan.getTagLabel()Ljava/lang/String;`